### PR TITLE
texvc support

### DIFF
--- a/unpacked/extensions/TeX/texvc.js
+++ b/unpacked/extensions/TeX/texvc.js
@@ -1,0 +1,136 @@
+/**
+ * From https://en.wikipedia.org/wiki/User:Nageh/mathJax/config/TeX-AMS-texvc_HTML.js
+ */
+
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var VERSION = "1.0";
+
+  var MML = MathJax.ElementJax.mml;
+
+  MathJax.Hub.Insert(MathJax.InputJax.TeX.Definitions,{
+
+    mathchar0mi: {
+      // Lowercase Greek letters
+      thetasym:     '03B8',  // theta
+      koppa:        '03DF',
+      stigma:       '03DB',
+      coppa:        '03D9',  // archaic koppa
+
+      // Ord symbols
+      C:            ['0043',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      cnums:        ['0043',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      Complex:      ['0043',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      H:            ['210D',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      N:            ['004E',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      natnums:      ['004E',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      Q:            ['0051',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      R:            ['0052',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      reals:        ['0052',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      Reals:        ['0052',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      Z:            ['005A',{mathvariant: MML.VARIANT.DOUBLESTRUCK}],
+      sect:         '00A7',  // S
+      P:            '00B6',
+      AA:           ['00C5',{mathvariant: MML.VARIANT.NORMAL}],  // Å, used for Angstrom
+      alef:         ['2135',{mathvariant: MML.VARIANT.NORMAL}],  // aleph
+      alefsym:      ['2135',{mathvariant: MML.VARIANT.NORMAL}],  // aleph
+      weierp:       ['2118',{mathvariant: MML.VARIANT.NORMAL}],  // wp
+      real:         ['211C',{mathvariant: MML.VARIANT.NORMAL}],  // Re
+      part:         ['2202',{mathvariant: MML.VARIANT.NORMAL}],  // partial
+      infin:        ['221E',{mathvariant: MML.VARIANT.NORMAL}],  // infty
+      empty:        ['2205',{mathvariant: MML.VARIANT.NORMAL}],  // emptyset
+      O:            ['2205',{mathvariant: MML.VARIANT.NORMAL}],  // emptyset (but should probably be Swedish O)
+      ang:          ['2220',{mathvariant: MML.VARIANT.NORMAL}],  // angle
+      exist:        ['2203',{mathvariant: MML.VARIANT.NORMAL}],  // exists
+      clubs:        ['2663',{mathvariant: MML.VARIANT.NORMAL}],  // clubsuit
+      diamonds:     ['2662',{mathvariant: MML.VARIANT.NORMAL}],  // diamondsuit
+      hearts:       ['2661',{mathvariant: MML.VARIANT.NORMAL}],  // heartsuit
+      spades:       ['2660',{mathvariant: MML.VARIANT.NORMAL}],  // spadesuit
+      textvisiblespace: '2423'
+    },
+
+    mathchar0mo: {
+      // Binary operators
+      and:          '2227',  // land
+      or:           '2228',  // lor
+      bull:         '2219',  // bullet
+      plusmn:       '00B1',  // pm
+      sdot:         '22C5',  // cdot
+
+      // Binary relations
+      sup:          '2283',  // supset
+      sub:          '2282',  // subset
+      supe:         '2287',  // supseteq
+      sube:         '2286',  // subseteq
+      isin:         '2208',  // in
+
+      hAar:               '21D4',  // Leftrightarrow [sic]
+      hArr:               '21D4',  // Leftrightarrow
+      Harr:               '21D4',  // Leftrightarrow
+      Lrarr:              '21D4',  // Leftrightarrow
+      lrArr:              '21D4',  // Leftrightarrow
+      lArr:               '21D0',  // Leftarrow
+      Larr:               '21D0',  // Leftarrow
+      rArr:               '21D2',  // Rightarrow
+      Rarr:               '21D2',  // Rightarrow
+      harr:               '2194',  // leftrightarrow
+      lrarr:              '2194',  // leftrightarrow
+      larr:               '2190',  // leftarrow
+      gets:               '2190',  // leftarrow
+      rarr:               '2192',   // rightarrow
+
+      // big ops
+      oiint:              ['222F',{texClass: MML.TEXCLASS.OP}],  // not part of texvc but nice to have
+      oiiint:             ['2230',{texClass: MML.TEXCLASS.OP}]
+    },
+
+    mathchar7: {
+      // Uppercase Greek letters
+      Alpha:        '0391',
+      Beta:         '0392',
+      Epsilon:      '0395',
+      Zeta:         '0396',
+      Eta:          '0397',
+      Iota:         '0399',
+      Kappa:        '039A',
+      Mu:           '039C',
+      Nu:           '039D',
+      Omicron:      '039F',
+      Rho:          '03A1',
+      Tau:          '03A4',
+      Chi:          '03A7',
+
+      Koppa:        '03DE',
+      Stigma:       '03DA',
+      Coppa:        '03D8'  // archaic Koppa
+    },
+
+    delimiter: {
+      '\\uarr':           '2191',  // uparrow
+      '\\darr':           '2193',  // downarrow
+      '\\Uarr':           '21D1',  // Uparrow
+      '\\uArr':           '21D1',  // Uparrow
+      '\\Darr':           '21D3',  // Downarrow
+      '\\dArr':           '21D3',  // Downarrow
+      '\\rang':           '27E9',  // rangle
+      '\\lang':           '27E8'   // langle
+    },
+
+    macros: {
+      sgn:                'NamedFn',
+      arccot:             'NamedFn',
+      arcsec:             'NamedFn',
+      arccsc:             'NamedFn',
+      bold:               ['Macro','\\mathbf{#1}',1],  // boldsymbol
+      href:               'NamedFn', // disable dangerous command
+      style:              'NamedFn', // disable dangerous command
+      pagecolor:          ['Macro','',1],  // ignore \pagecolor{}
+      vline:              ['Macro','\\smash{\\large\\lvert}',0],
+      image:              ['Macro','\\Im']
+    }
+
+  });
+});
+
+MathJax.Hub.Startup.signal.Post("TeX texvc Ready");
+
+MathJax.Ajax.loadComplete("[MathJax]/extensions/TeX/texvc.js");

--- a/unpacked/extensions/wiki2jax.js
+++ b/unpacked/extensions/wiki2jax.js
@@ -1,0 +1,80 @@
+/**
+ * From https://en.wikipedia.org/wiki/User:Nageh/mathJax/config/TeX-AMS-texvc_HTML.js
+ */
+
+MathJax.Extension.wiki2jax = {
+  version: "1.0",
+
+  config: {
+    element: null    // The ID of the element to be processed
+                      //   (defaults to full document)
+  },
+
+  PreProcess: function (element) {
+    if (!this.configured) {
+	  this.config = MathJax.Hub.CombineConfig("wiki2jax", this.config);
+      if (this.config.Augment) {MathJax.Hub.Insert(this,this.config.Augment)}
+
+      this.previewClass = MathJax.Hub.config.preRemoveClass;
+      this.setupPrefilter();
+      this.configured = true;
+    }
+    var that = this;
+    $('.mwe-math-fallback-png-display, .mwe-math-fallback-png-inline, .mwe-math-fallback-source-display,'+
+          '.mwe-math-fallback-source-inline, strong.texerror', element || document).each(function(i, span) {
+		that.ConvertMath(span);
+	});
+  },
+
+  setupPrefilter: function() {  // used to fix a number of common wiki math hacks
+    MathJax.Hub.Register.StartupHook("TeX Jax Ready", function() {
+      MathJax.InputJax.TeX.prefilterHooks.Add( function(data) {
+        data.math = data.math.replace(/^\s*\\scriptstyle(\W)/,"\\textstyle$1").replace(/^\s*\\scriptscriptstyle(\W)/,"\\scriptstyle$1");
+        if (data.script.type.match(/(;|\s|\n)mode\s*=\s*display-nobreak(;|\s|\n|$)/) != null)
+          data.math = "\\displaystyle " + data.math;
+      });
+    });
+  },
+
+  ConvertMath: function (node) {
+    var parent = node.parentNode,
+        mode = "", //Bug 61051 (heuristic unwanted by the community)
+		tex;
+	if (node.nodeName == 'IMG') {
+		tex = node.alt;
+	} else {
+          if (node.nodeName == 'STRONG') {
+            tex = $(node).text().replace(/^[^:]*: (.*)$/,"$1");
+          } else {
+            tex = $(node).text().replace(/^\$/,"").replace(/\$$/,"");
+          }
+          tex = tex.replace(/&lt;/g,"<").replace(/&gt;/g,">").replace(/&amp;/g,"&").replace(/&nbsp;/g," ");
+	}
+    if ( $( node ).hasClass( "mwe-math-fallback-png-display") || $( node ).hasClass( "mwe-math-fallback-source-display")  ){
+      mode = "; mode=display";
+    }
+    // We don't allow comments (%) in texvc and escape all literal % by default.
+    tex = tex.replace(/([^\\])%/g, "$1\\%" );
+
+    tex = tex.replace(/\\iiint([^!]*)!\\!\\!\\!\\!.*\\subset\\!\\supset/g,"\\iiint$1mkern-2.5em\\subset\\!\\supset").replace(/\\iint([^!]*)!\\!\\!\\!\\!\\!\\!\\!\\!\\!\\!(.*)\\subset\\!\\supset/g,"\\iint$1mkern-1.65em$2\\subset\\!\\!\\supset").replace(/\\int\\!\\!\\!(\\!)+\\int\\!\\!\\!(\\!)+\\int([^!]*)!\\!\\!\\!\\!.*\\bigcirc(\\,)*/g,"\\iiint$3mkern-2.5em\\subset\\!\\supset").replace(/\\int\\!\\!\\!(\\!)+\\int([^!]*)!\\!\\!\\!\\!\\!\\!\\!\\!(.*)\\bigcirc(\\,)*/g,"\\iint$2mkern-1.65em$3\\subset\\!\\!\\supset");
+
+    if (mode === "" && parent.firstChild === node) mode = "; mode=display-nobreak";
+
+    var script = document.createElement("script");
+    script.type = "math/tex" + mode;
+	MathJax.HTML.setScript(script, tex);
+
+    if (node.nextSibling) {parent.insertBefore(script,node.nextSibling)}
+      else {parent.appendChild(script)}
+
+    var preview = MathJax.HTML.Element("span", {
+      className: MathJax.Hub.config.preRemoveClass
+    });
+    preview.appendChild(parent.removeChild(node));
+    parent.insertBefore(preview, script);
+  }
+
+};
+
+MathJax.Hub.Register.PreProcessor(["PreProcess",MathJax.Extension.wiki2jax]);
+MathJax.Ajax.loadComplete("[MathJax]/extensions/wiki2jax.js");


### PR DESCRIPTION
Merge the texvc specific support back to standard MathJax
This will allow to merge new version of MathJax to MediaWiki easier.
